### PR TITLE
fix: error message for when contact tries issuing without demographics

### DIFF
--- a/src/UI/FormTestID.js
+++ b/src/UI/FormTestID.js
@@ -1,5 +1,7 @@
 import React, { useRef } from 'react'
 
+import { useNotification } from './NotificationProvider'
+
 import {
   StyledPopup,
   InputBox,
@@ -18,6 +20,7 @@ import {
 
 function FormTestID(props) {
   const credentialForm = useRef(null)
+  const setNotification = useNotification()
 
   const surname =
     props.contactSelected && props.contactSelected.Passport
@@ -185,7 +188,13 @@ function FormTestID(props) {
           value: form.get('ordering_facility_name') || '',
         },
       ]
+    } else {
+      return setNotification(
+        'Please "Edit" the Contact to Provide Demographic Information.',
+        'error'
+      )
     }
+
     let newCredential = {
       connectionID: props.contactSelected.Connections[0].connection_id,
       schemaID: 'X2JpGAqC7ZFY4hwKG6kLw9:2:Test_ID:1.2',

--- a/src/UI/FormTestResult.js
+++ b/src/UI/FormTestResult.js
@@ -1,5 +1,7 @@
 import React, { useRef } from 'react'
 
+import { useNotification } from './NotificationProvider'
+
 import {
   StyledPopup,
   InputBox,
@@ -18,6 +20,7 @@ import {
 
 function FormTestResult(props) {
   const credentialForm = useRef(null)
+  const setNotification = useNotification()
 
   const surname =
     props.contactSelected && props.contactSelected.Passport
@@ -219,7 +222,13 @@ function FormTestResult(props) {
           value: form.get('performing_lab') || '',
         },
       ]
+    } else {
+      return setNotification(
+        'Please "Edit" the Contact to Provide Demographic Information.',
+        'error'
+      )
     }
+
     let newCredential = {
       connectionID: props.contactSelected.Connections[0].connection_id,
       schemaID: 'X2JpGAqC7ZFY4hwKG6kLw9:2:Covid_19_Lab_Result:1.5',


### PR DESCRIPTION
Signed-off-by: Ammon Burgi <gitammonburgi@gmail.com>

# Summary of Changes

Set up an error message to catch when contact attempts to issue credentials without demographics.

# Related Issues

N/A

# Pull Request Checklist

This is just a reminder about the most common mistakes. Please make sure that you tick all _appropriate_ boxes. But please read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [ x ] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this).
- [ ] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components.
- [ ] Added **tests** for changed code (run `scripts/preflight` to run tests and check code style).
- [ ] Prefixed code comments with GitHub nick and an appropriate prefix.
- [ x ] Coding style is consistent with the rest of the framework.
- [ ] Updated **documentation** for changed code and new or modified features.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

_PR template adapted from the Python attrs project._
